### PR TITLE
Fix age = 0

### DIFF
--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -112,8 +112,9 @@ generateYieldTables <- function(cohortData, numSpeciesKeep = 3) {
   setkeyv(cds, c("speciesCode", "pixelGroup"))
 
   # Because LandR biomass will lump all age < 11 into age 0
-  if (sum(cds$age[cds$pixelGroup == 1] == 0) == 11)
+  if ((sum(cds$age[cds$pixelGroup == 1] == 0) %% 11) == 0) {
     cds[age == 0, age := 0:10, by = c("pixelGroup", "speciesCode")]
+  }
   # Fix the age = 0 problem
   cds[, maxB := max(B), by = c("pixelGroup", "speciesCode")]
   set(cds, NULL, "maxB", as.integer(cds$maxB))

--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -160,6 +160,7 @@ runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, species, sim
   if (!is.null(moduleNameAndBranch)) {
     getModule(moduleNameAndBranch, modulePath = paths$modulePath, overwrite = TRUE) # will only overwrite if wrong version
   }
+  speciesNameConvention <- LandR::equivalentNameColumn(species$species, LandR::sppEquivalencies_CA)
   cohortDataForYield <- Copy(cohortData)
   cohortDataForYield$B <- 1L
   cohortDataForYield$age <- 0L
@@ -188,8 +189,7 @@ runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, species, sim
   on.exit(options(opts))
   parameters <- list(
     .globals = list(
-      "sppEquivCol" = speciesNameConvention
-    ),
+      "sppEquivCol" = speciesNameConvention),
     Biomass_core = list(
       ".plotInitialTime" = timesForYield$start
       , ".plots" = NULL#c("screen", "png")


### PR DESCRIPTION
**Tiny fix to make Yield run (TBD if it works properly, but running is a first step)**

`generateYieldTables()` was not fixing the age = 0 problem. When there are more than 1 species in the `pixelGroup`,  `sum(cds$age[cds$pixelGroup == 1] == 0)` was greater than 11 (age 0-10).

When `cds` was made wider with `dcast()`, there was more than a single lines per combination of `pixelGroup` x `Age`, age 0 being repeated. `dcast()` then resolve to its default to return the number of lines instead of the `B`.

**Before:**
![Yield Curves from 40 random plots - 2025-01-09 14_08_07](https://github.com/user-attachments/assets/bd7156d0-c56c-47b2-b5a6-b45075e22258)
Notice how all species start with B=11 at age 0 and then goes to 1 at all other ages until longevity (11 lines of age = 0, 1 line of age = 11,12, ...).

**After:**
![Yield Curves from 40 random plots - 2025-01-10 12_16_05](https://github.com/user-attachments/assets/c1b23318-ad2c-4ce2-a15f-76e64dc3340e)
