### PR TITLE
new parameter: age range for yield table

### DIFF
--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -28,6 +28,8 @@ defineModule(sim, list(
     defineParameter("numPlots", "integer", 40L, NA, NA,
                     "When plotting the yield curves, this is how many unique pixel groups will ",
                     "be randomly selected and plotted"),
+    defineParameter("maxAge", "integer", NA, NA, NA,
+                    "The number of years for which the growth tables are created."),
     defineParameter("moduleNameAndBranch", "character", "PredictiveEcology/Biomass_core@development (>= 1.3.9)", NA, NA,
                     "The branch and version number required for Biomass_core. This will be downloaded ",
                     "into the file.path(dataPath(sim), 'module') of this module, so it does not ",
@@ -106,7 +108,7 @@ doEvent.Biomass_yieldTables = function(sim, eventTime, eventType) {
 GenerateData <- function(sim) {
   message("Running simulations for all PixelGroups")
   biomassCoresOuts <-  Cache(runBiomass_core, moduleNameAndBranch = Par$moduleNameAndBranch,
-                             paths = mod$paths, cohortData = sim$cohortData,
+                             paths = mod$paths, cohortData = sim$cohortData, maxAge = Par$maxAge,
                              species = sim$species, simEnv = envir(sim))
   sim$yieldOutputs <- biomassCoresOuts$simOutputs
   sim$yieldPixelGroupMap <- biomassCoresOuts$yieldPixelGroupMap

--- a/R/runBiomass_core.R
+++ b/R/runBiomass_core.R
@@ -1,6 +1,6 @@
 
 
-runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, species, simEnv) {
+runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, maxAge, species, simEnv) {
   # get modules if using stand alone module
   if (!is.null(moduleNameAndBranch)) {
     getModule(moduleNameAndBranch, modulePath = paths$modulePath, overwrite = TRUE) # will only overwrite if wrong version
@@ -10,7 +10,12 @@ runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, species, sim
   cohortDataForYield <- copy(cohortData)
   cohortDataForYield$B <- 1L
   cohortDataForYield$age <- 0L
-  timesForYield <- list(start = 0, end = max(species$longevity))
+  
+  
+  endTime <- ifelse(is.na(maxAge), 
+                    max(species$longevity), 
+                    min(maxAge, max(species$longevity)))
+  timesForYield <- list(start = 0, end = endTime)
   
   # The following line reduce the number of pixel groups. Pixels of the same 
   # ecoregion with the same species composition will produce the same Yield Tables. 

--- a/tests/testthat/devel_runTests.R
+++ b/tests/testthat/devel_runTests.R
@@ -1,5 +1,3 @@
-
-
 ## SET UP ----
 
 # Get needed packages

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,9 +1,10 @@
 if (!testthat::is_testing()){
-  library(testthat)
+  suppressPackageStartupMessages(library(testthat))
   testthat::source_test_helpers(env = globalenv())
 }
 
 # Source work in progress SpaDES module testing functions
+suppressPackageStartupMessages(library(SpaDES.core))
 tempScript <- tempfile(fileext = ".R")
 download.file(
   "https://raw.githubusercontent.com/suz-estella/SpaDES.core/refs/heads/suz-testthat/R/testthat.R",
@@ -14,7 +15,7 @@ source(tempScript)
 SpaDEStestSetGlobalOptions()
 
 # Set up testing directories
-spadesTestPaths <- SpaDEStestSetUpDirectories(copyModule = FALSE)
+spadesTestPaths <- SpaDEStestSetUpDirectories(require = 'googledrive')
 
 # Source the functions
 lapply(list.files(file.path(spadesTestPaths$RProj, "R"), full.names = TRUE), source)

--- a/tests/testthat/test-1-runBiomass_core.R
+++ b/tests/testthat/test-1-runBiomass_core.R
@@ -51,6 +51,7 @@ test_that("function runBiomass_core works", {
                          ),
                          cohortData = simOut$cohortData,
                          species = simOut$species,
+                         maxAge = NA,
                          simEnv = envir(simOut))
   
   if(updateFactorialOutputs) {
@@ -79,5 +80,32 @@ test_that("function runBiomass_core works", {
   expect_true(all(out$simOutputs$saveTime == c(1:nrow(out$simOutputs)-1)))
   expect_true(all(out$simOutputs$saved))
   expect_true(nrow(out$simOutputs) == max(simOut$species$longevity)+1)
+  
+  
+  out <- runBiomass_core(moduleNameAndBranch ="PredictiveEcology/Biomass_core@main", 
+                         paths = list(
+                           modulePath  = file.path(spadesTestPaths$temp$modules, "Biomass_yieldTables", "submodules"),
+                           inputPath   = spadesTestPaths$temp$inputs,
+                           outputPath = spadesTestPaths$temp$outputs
+                         ),
+                         cohortData = simOut$cohortData,
+                         species = simOut$species,
+                         maxAge = 20,
+                         simEnv = envir(simOut))
+  expect_equal(nrow(out$simOutputs), 21)
+  
+  
+  out <- runBiomass_core(moduleNameAndBranch ="PredictiveEcology/Biomass_core@main", 
+                         paths = list(
+                           modulePath  = file.path(spadesTestPaths$temp$modules, "Biomass_yieldTables", "submodules"),
+                           inputPath   = spadesTestPaths$temp$inputs,
+                           outputPath = spadesTestPaths$temp$outputs
+                         ),
+                         cohortData = simOut$cohortData,
+                         species = simOut$species,
+                         maxAge = 1000,
+                         simEnv = envir(simOut))
+  expect_true(nrow(out$simOutputs) == max(simOut$species$longevity)+1)
+  
   
 })

--- a/tests/testthat/test-1-runBiomass_core.R
+++ b/tests/testthat/test-1-runBiomass_core.R
@@ -68,11 +68,11 @@ test_that("function runBiomass_core works", {
   
   # inspect output class
   expect_is(out, "list")
-  expect_equal(names(out), c("simOutputs", "digest", "yieldPixelGroupMap"))
+  expect_named(out, c("simOutputs", "digest", "yieldPixelGroupMap"))
   expect_is(out$simOutputs, "data.frame")
   expect_is(out$digest, "list")
   expect_is(out$yieldPixelGroupMap, "SpatRaster")
-  expect_equal(names(out$digest), c("outputHash", "preDigest"))
+  expect_named(out$digest, c("outputHash", "preDigest"))
   
   #inspect simOutputs
   expect_true(all(out$simOutputs$objectName == "cohortData"))

--- a/tests/testthat/test-2-ReadExperimentFiles.R
+++ b/tests/testthat/test-2-ReadExperimentFiles.R
@@ -5,6 +5,7 @@ test_that("function ReadExperimentFiles works", {
   out <- SpaDEStestMuffleOutput(ReadExperimentFiles(factorialOutputs))
   
   expect_is(out, "data.table")
-  expect_true(all(names(out) == c("speciesCode", "age", "B", "pixelGroup")))
+  expect_named(out, c("speciesCode", "age", "B", "pixelGroup"))
+  expect_equal(max(out$age), nrow(factorialOutputs)-1)
   
 })

--- a/tests/testthat/test-3-generateYieldTables.R
+++ b/tests/testthat/test-3-generateYieldTables.R
@@ -16,18 +16,20 @@ test_that("function generateYieldTables works", {
   # inspect out
   expect_no_error(generateYieldTables(cohortDataAll))
   expect_is(out, "list")
-  expect_true(length(out) == 2)
-  expect_true(all(names(out) == c("cds", "cdSpeciesCodes")))
+  expect_named(out, c("cds", "cdSpeciesCodes"))
 
   # inspect cds
   expect_is(out$cds, "data.table")
-  expect_true(all(colnames(out$cds) %in% c("yieldPixelGroup", "age", "B", "cohort_id")))
+  expect_named(out$cds, c("yieldPixelGroup", "age", "B", "cohort_id"))
   expect_equal(sum(out$cds$age == 0), nsp*ngroup)
   expect_equal(nrow(out$cds), ngroup*(max(age)+1)*nsp)
   
   # inspect cdSpeciesCodes
-  expect_true(all(colnames(out$cdSpeciesCodes) %in% c("cohort_id", "yieldPixelGroup", "speciesCode")))
+  expect_named(out$cdSpeciesCodes, c("cohort_id", "yieldPixelGroup", "speciesCode"))
   expect_false(any(duplicated(out$cdSpeciesCodes$cohort_id)))
   expect_equal(nrow(out$cdSpeciesCodes), nsp*ngroup)
+  
+  expect_setequal(out$cds$cohort_id, out$cdSpeciesCodes$cohort_id)
+  expect_setequal(out$cds$yieldPixelGroup, out$cdSpeciesCodes$yieldPixelGroup)
   
 })

--- a/tests/testthat/test-6-Biomass_yieldTables.R
+++ b/tests/testthat/test-6-Biomass_yieldTables.R
@@ -78,7 +78,6 @@ test_that("module runs with small example", {
   simTest <-  SpaDEStestMuffleOutput(
     SpaDES.core::spades(simTestInit, debug = FALSE)
   )
-  
   # is output a simList?
   expect_s4_class(simTest, "simList")
   # does output have your module in it
@@ -86,12 +85,10 @@ test_that("module runs with small example", {
   
   # check output yieldTables
   expect_true(!is.null(simTest$yieldTables))
-  expect_true(inherits(simTest$yieldTables, "data.table"))
+  expect_is(simTest$yieldTables, "data.table")
   
-  expected_colnames <- c("yieldPixelGroup", "age", "B", "cohort_id")
-  expect_true(all(names(simTest$yieldTables) %in% expected_colnames))
-  expect_true(all(expected_colnames %in% names(simTest$yieldTables)))
-  
+  expect_named(simTest$yieldTables, c("yieldPixelGroup", "age", "B", "cohort_id"), ignore.order = TRUE)
+
   expect_type(simTest$yieldTables$yieldPixelGroup, "integer")
   expect_type(simTest$yieldTables$age, "integer")
   expect_type(simTest$yieldTables$B, "integer")
@@ -104,19 +101,28 @@ test_that("module runs with small example", {
   expect_true(all(simTest$yieldTables$B[simTest$CBM_AGB$age == 0] == 1))
   expect_true(all(simTest$yieldTables$B >= 1))
   expect_true(all(simTest$yieldTables$age >= 0))
+  expect_in(simTest$yieldTables$yieldPixelGroup, simTest$yieldPixelGroupMap[])
+  expect_setequal(simTest$yieldTables$cohort_id, simTest$yieldSpeciesCodes$cohort_id)
+  expect_setequal(simTest$yieldTables$yieldPixelGroup, simTest$yieldSpeciesCodes$yieldPixelGroup)
   
-  # check output CBM_speciesCodes
+  # check output yieldSpeciesCodes
   expect_true(!is.null(simTest$yieldSpeciesCodes))
-  expect_true(inherits(simTest$yieldSpeciesCodes, "data.table"))
+  expect_is(simTest$yieldSpeciesCodes, "data.table")
   
-  expected_colnames <- c("yieldPixelGroup", "cohort_id", "speciesCode")
-  expect_true(all(names(simTest$yieldSpeciesCodes) %in% expected_colnames))
-  expect_true(all(expected_colnames %in% names(simTest$yieldSpeciesCodes)))
+  expect_named(simTest$yieldSpeciesCodes, c("yieldPixelGroup", "cohort_id", "speciesCode"), ignore.order = TRUE)
   
   expect_type(simTest$yieldSpeciesCodes$yieldPixelGroup, "integer")
   expect_type(simTest$yieldSpeciesCodes$cohort_id, "integer")
   expect_is(simTest$yieldSpeciesCodes$speciesCode, "factor")
   
   expect_true(anyDuplicated(simTest$yieldSpeciesCodes$cohort_id) == 0)
+  expect_in(simTest$yieldSpeciesCodes$yieldPixelGroup, simTest$yieldPixelGroupMap[])
+  
+  # check output yieldPixelGroupMap
+  expect_is(simTest$yieldPixelGroupMap, "SpatRaster")
+  expect_equal(ext(simTest$yieldPixelGroupMap), ext(simTest$rasterToMatch))
+  expect_equal(crs(simTest$yieldPixelGroupMap), crs(simTest$rasterToMatch))
+  expect_equal(res(simTest$yieldPixelGroupMap), res(simTest$rasterToMatch))
+  expect_in(simTest$yieldPixelGroupMap[!is.nan(simTest$yieldPixelGroupMap)], simTest$yieldSpeciesCodes$yieldPixelGroup)
   
 })


### PR DESCRIPTION
I just added a parameter called `maxAge`  to control for the range of ages covered by the yieldTables. By default, the module created yield tables from age 0 to the longevity of the longest lived species (sometimes >500 years). If the user knows that the fire interval is much less than that, there is no reason to create yield tables that are that big (they can become huge, especially when they are later split into pools). Anyway, its a way to save RAM and computing time if the user do not need the yieldTables to go from 0 to X years.

That said, as mentioned in a earlier discussion. We need to figure out what to do when the fire interval will be large (e.g., coastal BC). I suspect that the spinup will get problematic when we reach ages when some species dies off completely.