### PR TITLE
setting minCohortBiomass when running Biomass_core

### DIFF
--- a/R/runBiomass_core.R
+++ b/R/runBiomass_core.R
@@ -66,6 +66,7 @@ runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, maxAge, spec
       , "vegLeadingProportion" = 0
       , "calcSummaryBGM" = NULL
       , "seedingAlgorithm" = "noSeeding"
+      , "minCohortBiomass" = 1
     )
   )
   paths$outputPath <- file.path(paths$outputPath, "cohortDataYield")

--- a/tests/testthat/devel_runTests.R
+++ b/tests/testthat/devel_runTests.R
@@ -1,17 +1,23 @@
 ## SET UP ----
 
-# Get needed packages
-packages = c("SpaDES.core", "SpaDES.project", "LandR", "data.table", "digest", "reproducible", "terra", "ggplot2")
-if (!requireNamespace("Require", quietly = TRUE)) {
-  install.packages("Require")
-}
-Require::Require(packages, dependencies = TRUE, repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
+# Install required packages
+## Required because module is not an R package
+install.packages(c("testthat", "SpaDES.core", "SpaDES.project"), repos = unique(c(
+  "predictiveecology.r-universe.dev", getOption("repos")
+)))
+
+Require::Require(c("data.table", "terra", "LandR", "SpaDES.core", "ggplot2"))
+
+## OPTIONS ----
 
 # Suppress warnings from calls to setupProject, simInit, and spades
 options("spades.test.suppressWarnings" = TRUE)
 
-# Set custom input data location
-options("reproducible.inputPaths" = NULL)
+# Set custom directory paths
+## Speed up tests by allowing inputs, cache, and R packages to persist between runs
+options("spades.test.paths.inputs"   = NULL) # inputPath
+options("spades.test.paths.cache"    = NULL) # cachePath
+options("spades.test.paths.packages" = NULL) # packagePath
 
 ## RUN ALL TESTS ----
 # Run all tests


### PR DESCRIPTION
A recent change in `Biomass_core` sets the default value of `minCohortBiomass` (cohorts with biomass < minCohortBiomass are removed) as 9. 

Since `Biomass_yieldTables` initially sets all biomasses to 1 g/m2, all cohorts were removed when running `Biomass_core` within the module. So, here I simply set the parameter to 1 when creating the yield tables.

The other changes are updating the test setup to make it more reproducible across machines.