### PR TITLE
Very small change to handle multiple module paths

### DIFF
--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -84,7 +84,7 @@ doEvent.Biomass_yieldTables = function(sim, eventTime, eventType) {
     init = {
       mod$paths <- paths(sim)
       if (!is.null(Par$moduleNameAndBranch)) {
-        mod$paths$modulePath <- file.path(modulePath(sim), currentModule(sim), "submodules")
+        mod$paths$modulePath <- file.path(modulePath(sim)[1], currentModule(sim), "submodules")
       }
       sim <- GenerateData(sim)
       


### PR DESCRIPTION
I've ran into an issue recently when there were multiple module paths (e.g., when running `scfm`). This is just a small change that should prevent that issue.