### PR TITLE
Fill non-treed pixels

### DIFF
--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -132,7 +132,7 @@ GenerateYieldTables <- function(sim) {
 PlotYieldTables <- function(sim) {
   fname = paste("Yield Curves from", Par$numPlots,
                 "random plots -", gsub(":", "_", sim$._startClockTime))
-  Plots(AGB = sim$yieldTablesCumulative, usePlot = FALSE, fn = pltfn,
+  Plots(data = sim$yieldTablesCumulative, usePlot = FALSE, fn = pltfn,
         numPlots = Par$numPlots,
         ggsaveArgs = list(width = 10, height = 7),
         filename = fname)

--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -108,6 +108,20 @@ GenerateData <- function(sim) {
   sim$yieldTablesId <- data.table(
     yieldTableIndex = as.integer(biomassCoresOuts$yieldPixelGroupMap[])
   )
+  ####
+  i <- 1L
+  while(any(sim$yieldTablesId$yieldTableIndex == 0) && i < 50){
+    message("Filling empty forest pixels: round ", i)
+    Npix <- sum(sim$yieldTablesId$yieldTableIndex == 0, na.rm = T)
+    message(Npix, " pixels to fill.")
+    windowSize = 1 + 2 * i
+    message("Using window size = ", windowSize)
+    focaledYldPixGrMap <- focal(biomassCoresOuts$yieldPixelGroupMap, w = windowSize, fun = "modal", na.rm = TRUE, na.policy="omit")
+    sim$yieldTablesId[yieldTableIndex == 0, "yieldTableIndex"] <- focaledYldPixGrMap[sim$yieldTablesId$yieldTableIndex == 0]
+    biomassCoresOuts$yieldPixelGroupMap[biomassCoresOuts$yieldPixelGroupMap == 0] <- focaledYldPixGrMap[biomassCoresOuts$yieldPixelGroupMap == 0]
+    i <- i + 1L
+  }
+  ####
   sim$yieldTablesId <- sim$yieldTablesId[, pixelIndex := .I] |> na.omit()
   setcolorder(sim$yieldTablesId, c("pixelIndex", "yieldTableIndex"))
   mod$digest <- biomassCoresOuts$digest

--- a/Biomass_yieldTables.R
+++ b/Biomass_yieldTables.R
@@ -109,17 +109,22 @@ GenerateData <- function(sim) {
     yieldTableIndex = as.integer(biomassCoresOuts$yieldPixelGroupMap[])
   )
   ####
+  windowSize <- 3L
   i <- 1L
-  while(any(sim$yieldTablesId$yieldTableIndex == 0) && i < 50){
-    message("Filling empty forest pixels: round ", i)
+  while(any(sim$yieldTablesId$yieldTableIndex == 0) && windowSize <= 10){
     Npix <- sum(sim$yieldTablesId$yieldTableIndex == 0, na.rm = T)
-    message(Npix, " pixels to fill.")
-    windowSize = 1 + 2 * i
+    message("Filling empty forest pixels: ", Npix, " pixels to fill.")
     message("Using window size = ", windowSize)
-    focaledYldPixGrMap <- focal(biomassCoresOuts$yieldPixelGroupMap, w = windowSize, fun = "modal", na.rm = TRUE, na.policy="omit")
-    sim$yieldTablesId[yieldTableIndex == 0, "yieldTableIndex"] <- focaledYldPixGrMap[sim$yieldTablesId$yieldTableIndex == 0]
-    biomassCoresOuts$yieldPixelGroupMap[biomassCoresOuts$yieldPixelGroupMap == 0] <- focaledYldPixGrMap[biomassCoresOuts$yieldPixelGroupMap == 0]
+    # replace 0 by NA
+    x <- biomassCoresOuts$yieldPixelGroupMap
+    x[x == 0] <- NA
+    focaledYldPixGrMap <- focal(x, w = windowSize, fun = "modal", na.rm = TRUE, na.policy="only")
+    newClasses <- focaledYldPixGrMap[sim$yieldTablesId$yieldTableIndex == 0]
+    idToReplace <- !is.na(sim$yieldTablesId$yieldTableIndex) & sim$yieldTablesId$yieldTableIndex == 0 & !is.na(focaledYldPixGrMap[])
+    sim$yieldTablesId[idToReplace, ] <- newClasses[!is.na(newClasses)]
+    biomassCoresOuts$yieldPixelGroupMap[idToReplace] <- focaledYldPixGrMap[idToReplace]
     i <- i + 1L
+    if(i %% 3 == 0) {windowSize <- windowSize + 2}
   }
   ####
   sim$yieldTablesId <- sim$yieldTablesId[, pixelIndex := .I] |> na.omit()

--- a/R/runBiomass_core.R
+++ b/R/runBiomass_core.R
@@ -34,7 +34,6 @@ runBiomass_core <- function(moduleNameAndBranch, paths, cohortData, maxAge, spec
   modPath <- file.path(paths$modulePath, "Biomass_core")
   filesToDigest <- c(dir(file.path(modPath, "R"), full.names = TRUE), file.path(modPath, "Biomass_core.R"))
   dig1 <- lapply(filesToDigest, function(fn) digest::digest(file = fn))
-  
   dig <- CacheDigest(list(species, cohortDataForYield, timesForYield, dig1))
   simOutputs <- expand.grid(objectName = "cohortData",
                             saveTime = unique(seq(timesForYield$start, timesForYield$end, by = 1)),

--- a/tests/testthat/devel_runTests.R
+++ b/tests/testthat/devel_runTests.R
@@ -1,13 +1,3 @@
-## SET UP ----
-
-# Install required packages
-## Required because module is not an R package
-install.packages(c("testthat", "SpaDES.core", "SpaDES.project"), repos = unique(c(
-  "predictiveecology.r-universe.dev", getOption("repos")
-)))
-
-Require::Require(c("data.table", "terra", "LandR", "SpaDES.core", "ggplot2"))
-
 ## OPTIONS ----
 
 # Suppress warnings from calls to setupProject, simInit, and spades
@@ -22,10 +12,6 @@ options("spades.test.paths.packages" = NULL) # packagePath
 ## RUN ALL TESTS ----
 # Run all tests
 testthat::test_dir(file.path("tests", "testthat"))
-
-# Run all tests with different reporters
-testthat::test_dir(file.path("tests", "testthat"), reporter = testthat::LocationReporter)
-testthat::test_dir(file.path("tests", "testthat"), reporter = testthat::SummaryReporter)
 
 ## RUN INDIVIDUAL TESTS ----
 testthat::test_file(file.path("tests", "testthat", "test-1-runBiomass_core.R"))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,4 @@
+
 if (!testthat::is_testing()){
   suppressPackageStartupMessages(library(testthat))
   testthat::source_test_helpers(env = globalenv())
@@ -11,11 +12,19 @@ download.file(
   tempScript, quiet = TRUE)
 source(tempScript)
 
-# Set up testing global options
+# Set up testing directories and global options
 SpaDEStestSetGlobalOptions()
-
-# Set up testing directories
-spadesTestPaths <- SpaDEStestSetUpDirectories(require = 'googledrive')
+spadesTestPaths <- SpaDEStestSetUpDirectories()
 
 # Source the functions
 lapply(list.files(file.path(spadesTestPaths$RProj, "R"), full.names = TRUE), source)
+Require::Require(c("data.table", "terra", "SpaDES.project"))
+
+# Install required packages
+withr::with_options(c(timeout = 600),
+  Require::Install(
+  c(SpaDES.core::packages(modules = basename(getwd()), paths = "..")[[1]],
+    "SpaDES.project", "googledrive", "data.table"),
+  repos = unique(c("predictiveecology.r-universe.dev", getOption("repos")))
+))
+


### PR DESCRIPTION
In LandR, I noticed that some pixels are classified as forest in the land cover layer but have no tree cohorts in the species layer. I’ll call these non-treed forest pixels. This can occur for two main reasons:

- Recent disturbances that have reduced aboveground biomass to zero.
- Data inconsistencies between the land cover and species source datasets.

This creates a problem at the start of the simulation: these pixels have zero carbon because no yield tables are assigned to them. In reality, they likely contain carbon in non-living pools (e.g., deadwood, litter, soil organic matter).

Proposed solution: assign each non-treed forest pixel the yield table of the nearest treed forest pixel. The algorithm searches neighbouring pixels in a 3×3 window, finds the most common yield table index among them, and assigns it to the non-treed pixel. This process is repeated three times, then expand the search radius by one pixel, until all forest pixels have a yield table index or the search radius exceeds four pixels (window size > 9×9):

Round 1: 3x3 window = look at immediate neighbour
Round 2: 3x3 window = look at immediate neighbour
Round 3: 3x3 window = look at immediate neighbour
Round 4: 5x5 window = look within a 2-pixel radius
Round 5: 5x5 window = look within a 2-pixel radius
Round 6: 5x5 window = look within a 2-pixel radius
Round 7: 7x7 window = look within a 3-pixel radius
Round 8: 7x7 window = look within a 3-pixel radius
Round 9: 7x7 window = look within a 3-pixel radius
Round 10: 9x9 window = look within a 4-pixel radius
Round 11: 9x9 window = look within a 4-pixel radius
Round 12: 9x9 window = look within a 4-pixel radius

This is purely arbitrary, and can be changed.